### PR TITLE
update onsenui to 2.12.10 and ngx-onsenui to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "cordova-plugin-splashscreen": "6.0.0",
     "core-js": "2.4.1",
     "monaca-plugin-monaca-core": "3.3.1",
-    "ngx-onsenui": "^7.0.0",
-    "onsenui": "2.11.2",
+    "ngx-onsenui": "^7.1.1",
+    "onsenui": "2.12.10",
     "rxjs": "^6.5.2",
     "zone.js": "0.8.26"
   },


### PR DESCRIPTION
Updates the Onsen UI dependencies so this Angular template can move off the old 2.11.2 line.

| dependency | before | after |
|---|---|---|
| `onsenui` | `2.11.2` | `2.12.10` |
| `ngx-onsenui` | `^7.0.0` | `^7.1.1` |

### Why it was stuck on 2.11.2

`ngx-onsenui`'s fesm bundle uses named imports from `onsenui`
(`import { PageLoader, _internal, notification, platform } from 'onsenui'`). The onsenui ESM entry stopped exposing those named exports once the `module` field was added in 2.12.0, so the names resolved to `undefined` and Angular broke at runtime. On top of that, `ngx-onsenui`'s exact-pinned `onsenui` peer made every onsenui bump fail with `ERESOLVE`.

Both are addressed upstream:
- onsenui restores the named exports on its ESM entry (OnsenUI/OnsenUI#3098) — ships in **2.12.10**.
- ngx-onsenui widens its peer to `^2.12.10` and releases as **7.1.1** (OnsenUI/OnsenUI#3099).

### ⚠️ Draft — blocked on release

`onsenui@2.12.10` and `ngx-onsenui@7.1.1` are **not published yet**, so `npm install` will fail and `www/` has not been rebuilt. This PR currently changes only `package.json`.

After both packages are on npm:

```
npm install
npm run build   # regenerates www/
```

then commit the rebuilt `www/` and mark this PR ready for review.